### PR TITLE
Tweak to C2C network note

### DIFF
--- a/vsphere/vsphere_ref_arch.html.md.erb
+++ b/vsphere/vsphere_ref_arch.html.md.erb
@@ -147,8 +147,7 @@ On the tenant side, each interface defined on the ESG acts as the IP gateway for
 
 [View a larger version of this diagram](../images/vsphere-exploded-edge.png).
 
-<p class="note"><strong>Note</strong>: Review the container-to-container settings in your installation for any IP address range conflicts with the enterprise addressing scheme in use. Change the range to a non-conflicting range as needed.</p>
-
+<p class="note"><strong>Note</strong>: Review the container-to-container settings in your installation for any IP address range conflicts with the enterprise addressing scheme in use. Change the range to a non-conflicting range as needed. The container-to-container network is only specified explicitly above to communicate to operators that this range should not be used elsewhere. Ideally it would be an entirely different range to any in use by the organisation.</p>
 ##### <a name="dist-port-group"> </a> Distributed Port Groups
 
 vSphere DVS (Distributed Virtual Switching) is recommended for all Clusters used by PCF. NSX will create a DPG (Distributed Port Group) for each interface provisioned on the ESG. 


### PR DESCRIPTION
Trying to make it clearer that C2C network is:
- not a network that needs to mean anything in wider organisation
- mainly being called out to avoid collisions