### PR TITLE
NSX clarifications

### DIFF
--- a/vsphere/vsphere_nsx_cookbook.html.md.erb
+++ b/vsphere/vsphere_nsx_cookbook.html.md.erb
@@ -181,7 +181,7 @@ To create the application profiles, access the ESG UI and perform the following 
 
     <%= image_tag('vsphere-app-profile-pcf-http.png') %>
 
-1. Create/Edit Profile and make the **PCF-HTTPS** rule, same as before, but add the service certificate inserted before.
+1. Create/Edit Profile and make the **PCF-HTTPS** rule, same as before, but add the service certificate inserted before.   If encrypting TLS traffic to the GoRouters, turn on **Enable Pool Side SSL**, otherwise leave it unchecked.
  
     <%= image_tag('vsphere-app-profile-pcf-https.png') %>
 
@@ -239,7 +239,7 @@ To create pool for `http-routers`, access the ESG UI and perform the following s
 1. Select **Edge**, **Manage**, **Load Balancer**, and then **Pools**.
 1. Enter ALL the IP addresses reserved for the Gorouters into this pool. If you reserved more addresses than you have Gorouters, enter the addresses anyway and the load balancer ignores the missing resources as "down".
     <p class="note"><strong>Note</strong>: If your deployment matches the [Reference Architecture for PCF on vSphere](./vsphere_ref_arch.html), these IP addresses are in the 192.168.20.0/22 address space.</p>
-1. If required, adjust **Port** and **Monitor Port**. Note that by default the port and monitoring port are on HTTP port 80. The assumption is that internal traffic from the ESG load balancer to the Gorouters is trusted because it is on a VXLAN secured within NSX. If using encrypted traffic inside the load balancer, adjust the ports accordingly.
+1. Set the **Port** to 80 and **Monitor Port** to 8080. The assumption is that internal traffic from the ESG load balancer to the Gorouters is trusted because it is on a VXLAN secured within NSX. If using encrypted TLS traffic to the Gorouter inside the VXLAN, set the **Port** to 443.
 1. Set the **Algorithm** to `ROUND-ROBIN`.
 1. Set **Monitors** to `http-routers`.
     <%= image_tag('vsphere-edit-pool-bordered.png') %>


### PR DESCRIPTION
for the http-routers pool, the HTTP monitor port is 8080, not 80 (the image shows 8080, the text says 80); also "Enable Pool Side SSL" is requried to be checked in the PCF-HTTPS application profile for TLS ecnryption to the Gorouter.

This applies to all PCF versions that include this cookbook.