### PR TITLE
Another NSX enhancement

### DIFF
--- a/vsphere/vsphere_nsx_cookbook.html.md.erb
+++ b/vsphere/vsphere_nsx_cookbook.html.md.erb
@@ -323,7 +323,8 @@ The ESG obfuscates the PCF installation through network translation. The PCF ins
 |Action|Applied on Interface|Original IP|Original Port|Translated IP|Translated Port|Protocol|Description|
 |---|---|---|---|---|---|---|---|
 |SNAT|uplink|192.168.0.0/16|any|IP\_of\_PCF|any|any|All Nets Egress|
-|DNAT|uplink|IP\_of\_OpsMgr|any|192.168.10.OpsMgr|any|tcp|OpsMgr Mask|
+|DNAT|uplink|IP\_of\_OpsMgr|any|192.168.10.OpsMgr|any|tcp|OpsMgr Mask for external use|
+|DNAT|infra|IP\_of\_OpsMgr|any|192.168.10.OpsMgr|any|tcp|OpsMgr Mask for internal use|
 
 NAT/SNAT functionality is not required if routable IP address space is used on the Tenant Side of the ESG. At that point, the ESG simply performs routing between the address segments.
 


### PR DESCRIPTION
Various setups requires some "internal" network interfaces to have a Hairpin NAT rule back to OpsMan because those components need to talk to the OpsMan API.  This shows an explicit DNAT entry from the Infra network itself for use with e.g. PCF-pipelines that are also installed on the infra network.     

PCF healthwatch complicates this RefArch because it (optionally) requires a service network to ping Ops Man as a healthcheck.  the commit doesn't show yet what it takes to make Healthwatch work with NSX as that requires a conversation about the security implications