### PR TITLE
Added Azure DNS reference.

### DIFF
--- a/azure/azure_ref_arch.html.md.erb
+++ b/azure/azure_ref_arch.html.md.erb
@@ -256,3 +256,7 @@ The key design points of this deployment are the following:
 <%= image_tag('azure-multi-resgroup-multi-lb.png') %>
 
 [View a larger version of this diagram](https://raw.githubusercontent.com/pivotal-cf/docs-pcf-refarch/master/images/azure-multi-resgroup-multi-lb.png).
+
+## DNS Delegation
+
+Azure DNS supports DNS delegation, allowing for sub-level domains to be hosted within Azure. This functionality is fully supported within Pivotal Cloud Foundry. It is recommended to use a sub-zone for your Pivotal Cloud Foundry; i.e. if your company's domain is `example.com`, your PCF zone in Azure DNS would be `pcf.example.com`. As Azure DNS does not support recursion, in order to properly configure Azure DNS, create an `NS` record with your registrar which points to the four name servers supplied by your Azure DNS Zone configuration. Once your `NS` records have been created, you can then create the required wildcard `A` records for the Pivotal Cloud Foundry application and system domains, as well as any other records desired for your PCF deployments. There are no configuration changes that need to be made in Pivotal Cloud Foundry to support Azure DNS.


### PR DESCRIPTION
This change was requested by Microsoft to have better first-party
references. Validated it works with PCF 1.x and 2.x. Should continue to
work open-ended as it's core infrastructure configs that have no direct
integration with PCF.

Signed-off-by: Mike Lloyd <mlloyd@pivotal.io>