### PR TITLE
Fixed grammar in vSphere ref arch

### DIFF
--- a/vsphere/vsphere_ref_arch.html.md.erb
+++ b/vsphere/vsphere_ref_arch.html.md.erb
@@ -217,7 +217,7 @@ For more information about configuring PKS with NSX-T networking, see [Installin
 
 <%= image_tag('../images/pks-with-nsxt.png') %>
 
-New T1 routers are be spawned on-demand as new namespaces are added to PKS. Because these can grow rapidly, a large address block is desired for this use.
+New T1 routers are spawned on-demand as new namespaces are added to PKS. Because these can grow rapidly, a large address block is desired for this use.
 The size of the address block is configurable and /24 by default.
 
 If you want to deploy PKS without NSX-T, see [Deploying PKS Without NSX-T](#without-nsxt) for more information.


### PR DESCRIPTION
"are be" isn't good grammar.