### PR TITLE
Fix broken Private Docker Registry link in docs

### DIFF
--- a/control.html.md.erb
+++ b/control.html.md.erb
@@ -179,7 +179,7 @@ There are a few alternatives to deploy BOSH Directors, Concourse servers, and ot
   - [Concourse with CredHub](https://github.com/pivotal-cf/pcf-pipelines/blob/master/docs/credhub-integration.md)
   - [Concourse with Vault](https://github.com/pivotal-cf/pcf-pipelines/blob/master/docs/vault-integration.md)
 * Docker registries
-  - [Private Docker Registry](https://github.com/pivotalservices/concourse-pipeline-samples/tree/master/private-docker-registry/docker-registry-release)
+  - [Private Docker Registry](https://github.com/pivotalservices/concourse-pipeline-samples/tree/master/concourse-pipeline-hacks/private-docker-registry/docker-registry-release)
   - [VMware Harbor Registry](https://github.com/vmware/harbor)
 * S3 buckets
   - [Minio S3](https://github.com/minio/minio-boshrelease)


### PR DESCRIPTION
The link provided was returning a 404 page not found. Fixed to point to correct path in concourse-pipeline-samples GitHub repo.