### PR TITLE
2.4

### DIFF
--- a/aws/aws_ref_arch.html.md.erb
+++ b/aws/aws_ref_arch.html.md.erb
@@ -7,7 +7,7 @@ owner: Customer0
 
 This guide presents a reference architecture for Pivotal Cloud Foundry (PCF) on Amazon Web Services (AWS). This architecture is valid for most production-grade PCF deployments using three availability zones (AZs).
 
-See [AWS on PCF Requirements](../../customizing/aws.html) for general requirements for running PCF and specific requirements for running PCF on AWS.
+See [PCF on AWS Requirements](../../customizing/aws.html) for general requirements for running PCF and specific requirements for running PCF on AWS.
 
 ## <a id="refarchs"></a>PCF Reference Architectures ##
 

--- a/control.html.md.erb
+++ b/control.html.md.erb
@@ -179,7 +179,7 @@ There are a few alternatives to deploy BOSH Directors, Concourse servers, and ot
   - [Concourse with CredHub](https://github.com/pivotal-cf/pcf-pipelines/blob/master/docs/credhub-integration.md)
   - [Concourse with Vault](https://github.com/pivotal-cf/pcf-pipelines/blob/master/docs/vault-integration.md)
 * Docker registries
-  - [Private Docker Registry](https://github.com/pivotalservices/concourse-pipeline-samples/tree/master/private-docker-registry/docker-registry-release)
+  - [Private Docker Registry](https://github.com/pivotalservices/concourse-pipeline-samples/tree/master/concourse-pipeline-hacks/private-docker-registry/docker-registry-release)
   - [VMware Harbor Registry](https://github.com/vmware/harbor)
 * S3 buckets
   - [Minio S3](https://github.com/minio/minio-boshrelease)

--- a/global-dns-lb.html.md.erb
+++ b/global-dns-lb.html.md.erb
@@ -1,13 +1,38 @@
 ---
-title: Using Global DNS Load Balancers for Multi-Foundation
+title: Global DNS Load Balancers for Multi-Foundation Installations
 ---
 
-This topic describes global DNS load balancers (GLBs) for multi-foundation deployments. This topic also describes concepts such as foundation affinity and healthchecks.
-
-Multi-foundation deployments are commonly deployed in an active-active or active-passive pattern.
+This topic describes global DNS load balancers (GLBs) for multi-foundation installations.
+This topic also describes concepts such as foundation affinity and healthchecks.
 
 <p class="note"><strong>Note:</strong> If you want to configure a load balancer dedicated
 to one PCF foundation and you are using an F5 LTM, see <a href="../customizing/f5-lb.html">Configuring an F5 Load Balancer for PAS</a>.</p>
+
+### <a id="multi-foundation"> About Multi-Foundation Installations
+
+Multi-foundation installations are multiple instances of BOSH and Ops Manager that can 
+communicate with each other. Each foundation can use different infrastructures to fit 
+your preferences.
+
+Multi-foundation installations are commonly deployed in an active-active or active-passive
+pattern. See below for descriptions of each term:
+
+<table>
+  <tr>
+    <th>Term</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><strong>Active-active pattern</strong></td>
+    <td>Instance so fapps run on two foundations and they are both in use.</td>
+  </tr>
+  <tr>
+    <td><strong>Active-passive pattern</strong></td>
+    <td>Instances of apps run on both foundations, but the instances may only be active
+    on one foundation. The other foundation becomes active only in the event of a
+    failover.</td>
+  </tr>
+</table>
 
 ## <a id="configure-glb"></a> Configure Your GLB
 

--- a/global-dns-lb.html.md.erb
+++ b/global-dns-lb.html.md.erb
@@ -1,20 +1,20 @@
 ---
-title: Global DNS Load Balancers for Multi-Foundation Installations
+title: Global DNS Load Balancers for Multi-Foundation Environments
 ---
 
-This topic describes global DNS load balancers (GLBs) for multi-foundation installations.
+This topic describes global DNS load balancers (GLBs) for multi-foundation environments.
 This topic also describes concepts such as foundation affinity and healthchecks.
 
 <p class="note"><strong>Note:</strong> If you want to configure a load balancer dedicated
 to one PCF foundation and you are using an F5 LTM, see <a href="../customizing/f5-lb.html">Configuring an F5 Load Balancer for PAS</a>.</p>
 
-### <a id="multi-foundation"> About Multi-Foundation Installations
+## <a id="multi-foundation"></a> About Multi-Foundation Environments
 
-Multi-foundation installations are multiple instances of BOSH and Ops Manager that can 
+Multi-foundation environments are multiple instances of BOSH and Ops Manager that can 
 communicate with each other. Each foundation can use different infrastructures to fit 
 your preferences.
 
-Multi-foundation installations are commonly deployed in an active-active or active-passive
+Multi-foundation environments are commonly deployed in an active-active or active-passive
 pattern. See below for descriptions of each term:
 
 <table>
@@ -23,12 +23,12 @@ pattern. See below for descriptions of each term:
     <th>Description</th>
   </tr>
   <tr>
-    <td><strong>Active-active pattern</strong></td>
-    <td>Instance so fapps run on two foundations and they are both in use.</td>
+    <td style="min-width: 10em;"><strong>Active-active pattern</strong></td>
+    <td>Instances of apps run on two foundations and they are both in use.</td>
   </tr>
   <tr>
     <td><strong>Active-passive pattern</strong></td>
-    <td>Instances of apps run on both foundations, but the instances may only be active
+    <td>Instances of apps run on two foundations, but the instances may only be active
     on one foundation. The other foundation becomes active only in the event of a
     failover.</td>
   </tr>

--- a/global-dns-lb.html.md.erb
+++ b/global-dns-lb.html.md.erb
@@ -1,0 +1,116 @@
+---
+title: Using Global DNS Load Balancers for Multi-Foundation
+---
+
+This topic describes global DNS load balancers (GLBs) for multi-foundation deployments. This topic also describes concepts such as foundation affinity and healthchecks.
+
+Multi-foundation deployments are commonly deployed in an active-active or active-passive pattern.
+
+<p class="note"><strong>Note:</strong> If you want to configure a load balancer dedicated
+to one PCF foundation and you are using an F5 LTM, see <a href="../customizing/f5-lb.html">Configuring an F5 Load Balancer for PAS</a>.</p>
+
+## <a id="configure-glb"></a> Configure Your GLB
+
+The typical setup for foundation failover requires the GLB be authoritative for a wildcard
+app domain. The wildcard app domain is not the same domain as the foundation-default app domain.
+
+To configure your GLB, do the following:
+
+- Find and record your wildcard app domain. For Pivotal Application Service
+(PAS), your wildcard app domain is typically the **Apps Domain** you configure in
+the **Domains** pane of the PAS tile.
+
+- Add the domain you recorded to both PCF foundations using a shared
+domain. You can create a shared domain using the Cloud Foundry Command Line Interface (cf
+CLI). For more information about the cf CLI command to create shared domains, see
+[create-shared-domain](https://cli.cloudfoundry.org/en-US/cf/create-shared-domain.html) in
+the cf CLI reference guide.
+
+- To support failover, set the time-to-live (TTL) in the wildcard DNS record. Set the TTL to about 30 to
+180 seconds. When determining your TTL, consider the tradeoff between the app
+performance impact and the resulting time for failover to occur.
+
+
+## <a id="foundation-affinity"></a> About Foundation Affinity
+
+_Foundation affinity_ occurs when the GLB favors one
+foundation over another during a route request. For example, users experience less latency
+if they are routed to a foundation that is geographically closer, so the GLB may favor
+that foundation.
+
+Different GLBs have their own mechanisms to achieve this. See the following table for common concepts:
+
+<table>
+  <tr>
+  <th colspan="2">Foundation Affinity Concepts</th>
+  <tr>
+  <tr>
+    <th>Term</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+  <td><strong>Topology/geographically-based affinity</strong></td>
+    <td>The GLB attempts to direct traffic to the
+graphically nearest foundation based on IP geolocation or provided topology for private
+networks of the LDNS server performing the lookup.
+</td>
+  </tr>
+  <tr>
+  <td><strong>Static-persist/member-hashing affinity</strong></td>
+    <td>The GLB attempts to direct traffic to the
+graphically nearest foundation based on IP geolocation or provided topology for private
+networks of the LDNS server performing the lookup.</td>
+  </tr>
+  <tr>
+    <td><strong>Active/passive foundations</strong></td>
+    <td>If one foundation is usually idle, you can always pick
+  the active foundation IP as long as it remains available.
+    </td>
+  </tr>
+    <tr>
+    <td><strong>Microservice-to-microservice affinity</strong></td>
+    <td>
+      For microservice apps, you typically use a Services
+  Registry to manage traffic between microservices. There are two ways to do this:
+    <ul>
+      <li style="margin:0"> If the microservices are using the
+      domain which maps to the GLB, then their traffic is routed through the GLB.</li>
+
+      <li>If the microservices are communicating using IP address or internal domains, such as when using Envoy, then the traffic does not pass through the GLB.</li>
+    </ul>
+    </td>
+  </tr>
+
+</table>
+
+
+
+## <a id="healthchecks"></a> About Healthchecks
+
+_Healthchecks_ determine whether a foundation for an app is healthy or not.
+
+See the following table for the levels at which you can check the health of your foundation:
+
+<table>
+  <tr>
+    <th>Level</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>Foundation</td>
+    <td>GLB relies on a local load balancer in front of the PCF Gorouters to determine the
+    overall health of the foundation. GLB can perform healthchecks on TCP port 443 or 80 or on the local load balancer.
+    The local load balancer healthchecks the backend pool of Gorouters on port 8080.</td>
+  </tr>
+  <tr>
+    <td>App</td>
+    <td>Healthchecks are set only for apps which have instances on both
+    foundations. Each app instance has canary DNS records. The canary DNS records are
+    the same for the app instances on each foundation. You would also need to add more VIPs dedicated to these canary apps that
+would be used to check their health. </td>
+  </tr>
+</table>
+<p class="note warning"><strong>WARNING</strong> Pivotal does not recommend setting healthchecks at the app level. Configuring
+healthchecks in this way can cause more frequent failover and delays while pushing apps.
+Complete failover of a foundation affects all apps on the platform. Healthchecks on a per-app basis can require additional overhead beyond the control of an app developer.</p>
+

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 breadcrumb: Pivotal Cloud Foundry Documentation
-title: Reference Architectures
+title: Platform Architecture and Planning 
 owner: Customer0
 ---
 

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -25,7 +25,8 @@ Pivotal has validated the following PCF products on its own deployments based on
 * Pivotal Container Services (PKS)
 
 
-## <a id="ref_archs"></a> Available Reference Architectures
+## <a id="ref_archs"></a> Available Reference Architectures and Planning Topics
+
 
 * [Pivotal Cloud Foundry on AWS](./aws/aws_ref_arch.html)
 * [Pivotal Cloud Foundry on Azure](./azure/azure_ref_arch.html)
@@ -33,3 +34,4 @@ Pivotal has validated the following PCF products on its own deployments based on
 * [Pivotal Cloud Foundry on OpenStack](./openstack/openstack_ref_arch.html)
 * [Pivotal Cloud Foundry on vSphere](./vsphere/vsphere_ref_arch.html)
 * [Control Plane Reference Architectures](./control.html)
+* [Implementing a Multi-Foundation PKS Deployment](https://docs.pivotal.io/runtimes/pks/1-2/nsxt-multi-pks.html)

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -25,7 +25,7 @@ Pivotal has validated the following PCF products on its own deployments based on
 * Pivotal Container Services (PKS)
 
 
-## <a id="ref_archs"></a> Available Reference Architectures and Planning Topics
+## <a id="ref_archs"></a> Available Platform Architectures and Planning Topics
 
 
 * [Pivotal Cloud Foundry on AWS](./aws/aws_ref_arch.html)

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -35,3 +35,4 @@ Pivotal has validated the following PCF products on its own deployments based on
 * [Pivotal Cloud Foundry on vSphere](./vsphere/vsphere_ref_arch.html)
 * [Control Plane Reference Architectures](./control.html)
 * [Implementing a Multi-Foundation PKS Deployment](https://docs.pivotal.io/runtimes/pks/1-2/nsxt-multi-pks.html)
+* [Using Global DNS Load Balancers for Multi-Foundation](./global-dns-lb.html)

--- a/vsphere/vsphere_ref_arch.html.md.erb
+++ b/vsphere/vsphere_ref_arch.html.md.erb
@@ -211,7 +211,7 @@ For more information about configuring PAS with NSX-T networking, see [Deploying
 Each new job, such as an isolation segment, falls to a broadcast domain or logical switch connected to a T1 router acting as the gateway to that network.
 This approach provides a DNAT and SNAT control point and a firewall boundary.
 
-TThe Services network is an exception. It shares a T1 router with any associated OD-Services# networks.
+The Services network is an exception. It shares a T1 router with any associated OD-Services# networks.
 Because these networks are considered part of the same system, inserting any NATs or firewall rules between them is not needed.
 
 #### <a id="load-balancing"></a> Load Balancing for PAS

--- a/vsphere/vsphere_ref_arch.html.md.erb
+++ b/vsphere/vsphere_ref_arch.html.md.erb
@@ -389,7 +389,7 @@ HA considerations include the following:
 
 * For non-production environments, the number of AZs that PAS requires for HA depends the location of its system databases.
   - With external databases, PAS requires two or more AZs for HA. For more information, see <a href="https://docs-pcf-staging.cfapps.io/pivotalcf/2-5/customizing/config-er-vmware.html#create-dbs">External Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
-  - With internal system databases, PAS requires three or more AZs for HA. Fore more information, see <a href="../../customizing/config-er-vmware.html#internal-db">Internal Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
+  - With internal system databases, PAS requires three or more AZs for HA. For more information, see <a href="../../customizing/config-er-vmware.html#internal-db">Internal Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
 
 * For non-production environments, PAS is HA when it runs across two or three AZs with external system databases. For more information, see </a> .</a>. PAS is only HA with internal databases when it has three AZs.
 

--- a/vsphere/vsphere_ref_arch.html.md.erb
+++ b/vsphere/vsphere_ref_arch.html.md.erb
@@ -51,8 +51,10 @@ Instead, it gives examples of how to apply those instructions to real-world prod
 This reference architecture includes VMware vSphere and NSX-T, a software-defined network virtualization platform that runs on VMware ESXi virtual hosts.
 
 The reference architecture supports capacity growth at the vSphere and PCF levels as well as installation security through the NSX-T firewall.
-It allocates a minimum of three servers to each cluster and spreads PCF components across three clusters for high availability (HA).
+It allocates a minimum of three servers to each vSphere cluster and spreads PCF components across three clusters for high availability (HA). Each vSphere cluster corresponds to an Availability Zone (AZ).
 For information about HA in PCF, see [High Availability in Cloud Foundry](../../concepts/high-availability.html).
+
+<p class="note"><strong>Note</strong>: Small and non-critical deployments can maintain high availability with two vSphere clusters instead of three, provided that the PAS system databases are <a href="../../customizing/config-er-vmware.html#create-dbs">configured as external</a>.</p>
 
 To use all features listed in this topic for your PAS installation, you must have **Advanced** or above licensing from VMware for NSX-T.
 For PKS, the required licensing is included by default.
@@ -385,14 +387,18 @@ However, high core count VMs become increasingly hard to schedule on the pCPU wi
 
 HA considerations include the following:
 
-* PAS is not considered HA until at least two AZs are defined. Pivotal recommends using three AZs for HA.
+* For non-production environments, PAS is HA when it runs across two AZs with [external system databases](../../customizing/config-er-vmware.html#create-dbs), or runs across three AZs when its system databases are [internal](../../customizing/config-er-vmware.html#internal-db).
 
-    PCF achieves redundancy through the AZ construct and the loss of an AZ is not considered catastrophic.
-    BOSH Resurrector can replace lost VMs as needed to repair a foundation.
-    Foundation backup and restoration is accomplished externally by BOSH Backup and Restore (BBR).
-    For information about BBR, see [Backing Up and Restoring Pivotal Cloud Foundry](../../customizing/backup-restore/index.html).
+* For any production environment, Pivotal recommends using three AZs for HA.
 
 * PKS has no inherent HA capabilities to design for. To support PKS, design HA at the IaaS, storage, power, and access layers.
+
+PCF achieves redundancy through the AZ construct, and the loss of an AZ is not considered catastrophic.
+BOSH Resurrector replaces lost VMs as needed to repair a foundation.
+
+Foundation backup and restoration is accomplished externally by BOSH Backup and Restore (BBR).
+For information about BBR, see [Backing Up and Restoring Pivotal Cloud Foundry](../../customizing/backup-restore/index.html).
+
 
 ### <a id="scaling"></a> Scaling and Capacity Management
 

--- a/vsphere/vsphere_ref_arch.html.md.erb
+++ b/vsphere/vsphere_ref_arch.html.md.erb
@@ -387,13 +387,11 @@ However, high core count VMs become increasingly hard to schedule on the pCPU wi
 
 HA considerations include the following:
 
-* For non-production environments, the number of AZs that PAS requires for HA depends the location of its system databases.
-  - With external databases, PAS requires two or more AZs for HA. For more information, see <a href="https://docs-pcf-staging.cfapps.io/pivotalcf/2-5/customizing/config-er-vmware.html#create-dbs">External Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
-  - With internal system databases, PAS requires three or more AZs for HA. For more information, see <a href="../../customizing/config-er-vmware.html#internal-db">Internal Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
+* For non-production environments, the number of AZs that PAS requires for HA depends on the location of its system databases.
+  - With external databases, PAS requires at least two AZs for HA. For more information, see <a href="https://docs-pcf-staging.cfapps.io/pivotalcf/2-5/customizing/config-er-vmware.html#create-dbs">External Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
+  - With internal system databases, PAS requires at least three AZs for HA. For more information, see <a href="../../customizing/config-er-vmware.html#internal-db">Internal Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
 
-* For non-production environments, PAS is HA when it runs across two or three AZs with external system databases. For more information, see </a> .</a>. PAS is only HA with internal databases when it has three AZs.
-
-* For any production environment, Pivotal recommends using three AZs for HA.
+* For any production environment, Pivotal recommends using at least three AZs for HA.
 
 * PKS has no inherent HA capabilities to design for. To support PKS, design HA at the IaaS, storage, power, and access layers.
 

--- a/vsphere/vsphere_ref_arch.html.md.erb
+++ b/vsphere/vsphere_ref_arch.html.md.erb
@@ -54,7 +54,7 @@ The reference architecture supports capacity growth at the vSphere and PCF level
 It allocates a minimum of three servers to each vSphere cluster and spreads PCF components across three clusters for high availability (HA). Each vSphere cluster corresponds to an Availability Zone (AZ).
 For information about HA in PCF, see [High Availability in Cloud Foundry](../../concepts/high-availability.html).
 
-<p class="note"><strong>Note</strong>: Small and non-critical deployments can maintain high availability with two vSphere clusters instead of three, provided that the PAS system databases are <a href="../../customizing/config-er-vmware.html#create-dbs">configured as external</a>.</p>
+<p class="note"><strong>Note</strong>: Small and non-critical deployments can maintain high availability with two vSphere clusters instead of three, provided that the PAS system databases are configured as external. For more information, see <a href="../../customizing/config-er-vmware.html#create-dbs">External Database Configuration</a> in <em>Deploying PAS on vSphere</em>.</p>
 
 To use all features listed in this topic for your PAS installation, you must have **Advanced** or above licensing from VMware for NSX-T.
 For PKS, the required licensing is included by default.
@@ -387,7 +387,11 @@ However, high core count VMs become increasingly hard to schedule on the pCPU wi
 
 HA considerations include the following:
 
-* For non-production environments, PAS is HA when it runs across two AZs with [external system databases](../../customizing/config-er-vmware.html#create-dbs), or runs across three AZs when its system databases are either [internal](../../customizing/config-er-vmware.html#internal-db) or external.
+* For non-production environments, the number of AZs that PAS requires for HA depends the location of its system databases.
+  - With external databases, PAS requires two or more AZs for HA. For more information, see <a href="https://docs-pcf-staging.cfapps.io/pivotalcf/2-5/customizing/config-er-vmware.html#create-dbs">External Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
+  - With internal system databases, PAS requires three or more AZs for HA. Fore more information, see <a href="../../customizing/config-er-vmware.html#internal-db">Internal Database Configuration</a> in <em>Deploying PAS on vSphere</em>.
+
+* For non-production environments, PAS is HA when it runs across two or three AZs with external system databases. For more information, see </a> .</a>. PAS is only HA with internal databases when it has three AZs.
 
 * For any production environment, Pivotal recommends using three AZs for HA.
 

--- a/vsphere/vsphere_ref_arch.html.md.erb
+++ b/vsphere/vsphere_ref_arch.html.md.erb
@@ -387,7 +387,7 @@ However, high core count VMs become increasingly hard to schedule on the pCPU wi
 
 HA considerations include the following:
 
-* For non-production environments, PAS is HA when it runs across two AZs with [external system databases](../../customizing/config-er-vmware.html#create-dbs), or runs across three AZs when its system databases are [internal](../../customizing/config-er-vmware.html#internal-db).
+* For non-production environments, PAS is HA when it runs across two AZs with [external system databases](../../customizing/config-er-vmware.html#create-dbs), or runs across three AZs when its system databases are either [internal](../../customizing/config-er-vmware.html#internal-db) or external.
 
 * For any production environment, Pivotal recommends using three AZs for HA.
 


### PR DESCRIPTION
Hey folks, regarding the vsphere refarch: https://docs.pivotal.io/pivotalcf/2-2/refarch/vsphere/vsphere_ref_arch.html

Please remove in docs ‘Note: HTTPS with NSX-T-provided ingress is not currently supported’ It is supported if NSX-T => 2.2
- https is supported when NSX-T => 2.2

Thanks!