### PR TITLE
The URL link for Out-of-Sync Error issue

### DIFF
--- a/vsphere/vsphere_migrate_datastore.html.md.erb
+++ b/vsphere/vsphere_migrate_datastore.html.md.erb
@@ -90,7 +90,7 @@ When BOSH moves disks, it waits for up to 60 minutes for the operation to comple
 
 ### <a id="fix_sync_error"></a> Fix Failed BOSH Deployment with Out-of-Sync Error
 
-If your PCF deployment gets into this state, you can resolve the issue by performing the steps in the KB article [How to recover from a failed bosh deployment when VMs are out of sync on vSphere](https://discuss.pivotal.io/hc/en-us/articles/218051768-How-to-recover-from-a-failed-bosh-deployment-when-VMs-are-out-of-sync-on-Vsphere).
+If your PCF deployment gets into this state, you can resolve the issue by performing the steps in the KB article [How to Recover the out of Sync VMs on vSphere from a Failed BOSH Deployment](https://community.pivotal.io/s/article/How-to-Recover-the-out-of-Sync-VMs-on-vSphere-from-a-Failed-Bosh-Deployment).
 
 ### <a id="prevent_sync_error"></a> Prevent Out-of-Sync Error
  


### PR DESCRIPTION
The URL link for the KB to resolve Out-of-Sync Error issue was obsolete. The correct URL is as below.
https://community.pivotal.io/s/article/How-to-Recover-the-out-of-Sync-VMs-on-vSphere-from-a-Failed-Bosh-Deployment