### PR TITLE
"Recreate all VMs" has been renamed in 2.9- updates docs

### DIFF
--- a/vsphere/vsphere_migrate_datastore.html.md.erb
+++ b/vsphere/vsphere_migrate_datastore.html.md.erb
@@ -94,7 +94,7 @@ To migrate your <%= vars.platform_name %> deployment to a new datastore:
 
 1. In the BOSH Director tile, select **Director Config**.
 
-1. Select the **Recreate all VMs** option.
+1. Select the **Recreate VMs deployed by the BOSH Director** option.
 
 1. Click **Review Pending Changes**, then **Apply Changes**.
 


### PR DESCRIPTION
[#170244457] The recreate-all-vms checkbox is incorrectly named

Signed-off-by: Kenneth Lakin <klakin@pivotal.io>